### PR TITLE
Use tor for data reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The monitor project collects data and sends it to the Graphite data source which
 
 We use 3 approaches to collect data about the state of the seed nodes.
 
-1. The seed nodes send per clear net messages to the monitoring server. Those messages contain information about the
+1. The seed nodes report data over Tor to the monitoring server. Reported data includes information about the
    state of messages, used memory and DAO hashes.
 2. A tor node pings on a regular interval all seed nodes to measure round trip time and to see if the seed node is
    reachable over tor.

--- a/scripts/bisq-monitor-13002.conf
+++ b/scripts/bisq-monitor-13002.conf
@@ -1,0 +1,5 @@
+PROXY_HOST=127.0.0.1
+PROXY_PORT=9050
+LOCAL_PORT=9082
+REMOTE_HOST=bisqmonorsysbgqnma5ghacqgc2pyobk5gezlfo4q5wkemq66r47vmqd.onion
+REMOTE_PORT=13002

--- a/scripts/bisq-monitor-2002.conf
+++ b/scripts/bisq-monitor-2002.conf
@@ -1,0 +1,5 @@
+PROXY_HOST=127.0.0.1
+PROXY_PORT=9050
+LOCAL_PORT=9081
+REMOTE_HOST=bisqmonorsysbgqnma5ghacqgc2pyobk5gezlfo4q5wkemq66r47vmqd.onion
+REMOTE_PORT=2002

--- a/scripts/collectd.conf
+++ b/scripts/collectd.conf
@@ -9,7 +9,7 @@ LoadPlugin cpu
 
 LoadPlugin df
 <Plugin df>
-	MountPoint true
+	MountPoint "/"
 </Plugin>
 
 LoadPlugin disk

--- a/scripts/collectd.conf
+++ b/scripts/collectd.conf
@@ -93,6 +93,10 @@ LoadPlugin memory
 LoadPlugin processes
 
 LoadPlugin swap
+<Plugin swap>
+	ValuesAbsolute false
+	ValuesPercentage true
+</Plugin>
 
 LoadPlugin syslog
 <Plugin syslog>

--- a/scripts/collectd.conf
+++ b/scripts/collectd.conf
@@ -1,52 +1,42 @@
 Hostname "__ONION_ADDRESS__"
 Interval 30
 
-LoadPlugin syslog
-<Plugin syslog>
-	LogLevel info
-</Plugin>
-
 LoadPlugin cpu
-LoadPlugin df
-LoadPlugin disk
-LoadPlugin fhcount
-LoadPlugin interface
-LoadPlugin java
-LoadPlugin load
-LoadPlugin memory
-LoadPlugin processes
-LoadPlugin swap
-LoadPlugin write_graphite
-
 <Plugin cpu>
 	ReportByCpu true
 	ValuesPercentage true
 </Plugin>
 
+LoadPlugin df
 <Plugin df>
-	MountPoint "/"
+	MountPoint true
 </Plugin>
 
-<Plugin disk>
-	Disk "/[hs]da/"
-</Plugin>
+LoadPlugin disk
 
+LoadPlugin fhcount
 <Plugin fhcount>
 	ValuesAbsolute false
 	ValuesPercentage true
 </Plugin>
 
+LoadPlugin interface
 <Plugin interface>
-	Interface "eth0"
+	Interface "lo"
+    IgnoreSelected true
 </Plugin>
 
+LoadPlugin java
 <Plugin java>
 	JVMArg "-verbose:jni"
 	JVMArg "-Djava.class.path=/usr/share/collectd/java/collectd-api.jar:/usr/share/collectd/java/generic-jmx.jar"
 
 	LoadPlugin "org.collectd.java.GenericJMX"
 	<Plugin "GenericJMX">
-		# Generic heap/nonheap memory usage.
+		# See /usr/share/doc/collectd/examples/GenericJMX.conf
+		# for an example config.
+
+		# Generic heap/nonheap memory usage
 		<MBean "memory">
 			ObjectName "java.lang:type=Memory"
 			#InstanceFrom ""
@@ -73,7 +63,7 @@ LoadPlugin write_graphite
 			</Value>
 		</MBean>
 		
-		# Memory usage by memory pool.
+		# Memory usage by memory pool
 		<MBean "memory_pool">
 			ObjectName "java.lang:type=MemoryPool,*"
 			InstancePrefix "memory_pool-"
@@ -93,31 +83,23 @@ LoadPlugin write_graphite
 			Collect "memory_pool"
 			Collect "memory"
 		</Connection>
-		
-		# See /usr/share/doc/collectd/examples/GenericJMX.conf
-		# for an example config.
 	</Plugin>
 </Plugin>
 
-#<Plugin load>
-#	ReportRelative true
-#</Plugin>
+LoadPlugin load
 
-#<Plugin memory>
-#	ValuesAbsolute true
-#	ValuesPercentage false
-#</Plugin>
+LoadPlugin memory
 
-#<Plugin processes>
-#	Process "name"
-#	ProcessMatch "foobar" "/usr/bin/perl foobar\\.pl.*"
-#</Plugin>
+LoadPlugin processes
 
-#<Plugin swap>
-#	ReportByDevice false
-#	ReportBytes true
-#</Plugin>
+LoadPlugin swap
 
+LoadPlugin syslog
+<Plugin syslog>
+	LogLevel info
+</Plugin>
+
+LoadPlugin write_graphite
 <Plugin write_graphite>
 	<Node "node">
 		Host "127.0.0.1"

--- a/scripts/http-to-socks-proxy@.service
+++ b/scripts/http-to-socks-proxy@.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=HTTP-to-SOCKS proxy
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/http-to-socks-proxy/%i.conf
+ExecStart=/usr/bin/socat tcp4-LISTEN:${LOCAL_PORT},reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS4A:${PROXY_HOST}:${REMOTE_HOST}:${REMOTE_PORT},socksport=${PROXY_PORT}
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/install_collectd_debian.sh
+++ b/scripts/install_collectd_debian.sh
@@ -33,8 +33,8 @@ echo "[*] Configuring JVM options to allow for monitoring"
 for file in "${SYSTEMD_ENV_HOME}/bisq.env" "${SYSTEMD_ENV_HOME}/bisq-pricenode.env"
 do
     if [ -f "$file" ];then
-        sed -i -e 's/-Dcom.sun.management.jmxremote //g' -e 's/-Dcom.sun.management.jmxremote.local.only=true//g' -e 's/ -Dcom.sun.management.jmxremote.host=127.0.0.1//g' -e 's/ -Dcom.sun.management.jmxremote.port=6969//g' -e 's/ -Dcom.sun.management.jmxremote.rmi.port=6969//g' -e 's/ -Dcom.sun.management.jmxremote.ssl=false//g' -e 's/ -Dcom.sun.management.jmxremote.authenticate=false//g' "${file}"
-        sed -i -e '/JAVA_OPTS/ s/"$/ -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.host=127.0.0.1 -Dcom.sun.management.jmxremote.port=6969 -Dcom.sun.management.jmxremote.rmi.port=6969 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false"/' "${file}"
+        sed -i -e 's/-Dcom.sun.management.jmxremote //g' -e 's/-Dcom.sun.management.jmxremote.local.only=true//g' -e 's/ -Dcom.sun.management.jmxremote.host=127.0.0.1//g' -e 's/ -Dcom.sun.management.jmxremote.port=6969//g' -e 's/ -Dcom.sun.management.jmxremote.rmi.port=6969//g' -e 's/ -Dcom.sun.management.jmxremote.ssl=false//g' -e 's/ -Dcom.sun.management.jmxremote.authenticate=false//g' -e 's/ -Djava.rmi.server.hostname=127.0.0.1//g' "${file}"
+        sed -i -e '/JAVA_OPTS/ s/"$/ -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=true -Dcom.sun.management.jmxremote.host=127.0.0.1 -Dcom.sun.management.jmxremote.port=6969 -Dcom.sun.management.jmxremote.rmi.port=6969 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=127.0.0.1"/' "${file}"
     fi
 done
 

--- a/scripts/install_collectd_debian.sh
+++ b/scripts/install_collectd_debian.sh
@@ -3,22 +3,22 @@ set -e
 
 # Usage: `$ sudo ./install_collectd_debian.sh`
 
-echo "[*] Bisq Server Monitoring installation script"
+echo "[*] Bisq server monitoring installation script"
 
-##### change paths if necessary for your system
+##### Change parameters if necessary for your system
 BISQ_MONITOR_REPO_URL=https://raw.githubusercontent.com/bisq-network/bisq-monitor
 BISQ_MONITOR_REPO_TAG=main
 ROOT_USER=root
 ROOT_GROUP=root
 ROOT_HOME=~root
-ROOT_PKG=(curl patch nginx collectd openssl)
+ROOT_PKG=(curl patch nginx libnginx-mod-stream collectd openssl socat tor basez)
 
 SYSTEMD_ENV_HOME=/etc/default
 
 #####
 
 echo "[*] Gathering information"
-read -p "Please provide the onion address of your service (eg. 3f3cu2yw7u457ztq): " onionaddress
+read -p "Please provide the onion address of your service, without \".onion\" (eg. runbtcsd42pwlfna32ibcrrykrcmozgv6x73sxjrdohkm55v5f6nh6ad): " onionaddress
 
 echo "[*] Updating apt repo sources"
 DEBIAN_FRONTEND=noninteractive apt-get update -q
@@ -29,8 +29,7 @@ DEBIAN_FRONTEND=noninteractive apt-get upgrade -qq -y
 echo "[*] Installing base packages"
 DEBIAN_FRONTEND=noninteractive apt-get install -qq -y ${ROOT_PKG[@]}
 
-echo "[*] Preparing Bisq init script for monitoring"
-# remove stuff it it is there already
+echo "[*] Configuring JVM options to allow for monitoring"
 for file in "${SYSTEMD_ENV_HOME}/bisq.env" "${SYSTEMD_ENV_HOME}/bisq-pricenode.env"
 do
     if [ -f "$file" ];then
@@ -41,8 +40,8 @@ done
 
 echo "[*] Seeding entropy from /dev/urandom"
 /bin/sh -c "head -1500 /dev/urandom > ${ROOT_HOME}/.rnd"
+
 echo "[*] Installing Nginx config"
-openssl req -x509 -nodes -newkey rsa:2048 -days 3000 -keyout /etc/nginx/cert.key -out /etc/nginx/cert.crt -subj="/O=Bisq/OU=Bisq Infrastructure/CN=$onionaddress"
 curl -s "${BISQ_MONITOR_REPO_URL}/${BISQ_MONITOR_REPO_TAG}/scripts/nginx.conf" > /tmp/nginx.conf
 install -c -o "${ROOT_USER}" -g "${ROOT_GROUP}" -m 644 /tmp/nginx.conf /etc/nginx/nginx.conf
 
@@ -51,10 +50,26 @@ curl -s "${BISQ_MONITOR_REPO_URL}/${BISQ_MONITOR_REPO_TAG}/scripts/collectd.conf
 install -c -o "${ROOT_USER}" -g "${ROOT_GROUP}" -m 644 /tmp/collectd.conf /etc/collectd/collectd.conf
 sed -i -e "s/__ONION_ADDRESS__/$onionaddress/" /etc/collectd/collectd.conf
 
-echo "[*] Updating systemd daemon configuration"
-systemctl daemon-reload
-systemctl enable nginx.service
-systemctl enable collectd.service
+echo "[*] Installing http-to-socks-proxy config"
+curl -s "${BISQ_MONITOR_REPO_URL}/${BISQ_MONITOR_REPO_TAG}/scripts/http-to-socks-proxy@.service" > /tmp/http-to-socks-proxy@.service
+install -c -o "${ROOT_USER}" -g "${ROOT_GROUP}" -m 644 /tmp/http-to-socks-proxy@.service /etc/systemd/system/http-to-socks-proxy@.service
+curl -s "${BISQ_MONITOR_REPO_URL}/${BISQ_MONITOR_REPO_TAG}/scripts/bisq-monitor-2002.conf" > /tmp/bisq-monitor-2002.conf
+curl -s "${BISQ_MONITOR_REPO_URL}/${BISQ_MONITOR_REPO_TAG}/scripts/bisq-monitor-13002.conf" > /tmp/bisq-monitor-13002.conf
+mkdir -p /etc/http-to-socks-proxy/
+install -c -o "${ROOT_USER}" -g "${ROOT_GROUP}" -m 644 /tmp/bisq-monitor-2002.conf /etc/http-to-socks-proxy/bisq-monitor-2002.conf
+install -c -o "${ROOT_USER}" -g "${ROOT_GROUP}" -m 644 /tmp/bisq-monitor-13002.conf /etc/http-to-socks-proxy/bisq-monitor-13002.conf
+
+echo "[*] Generating Tor client authorization key"
+openssl genpkey -algorithm x25519 -out /tmp/k1.prv.pem
+private_key=$(cat /tmp/k1.prv.pem | grep -v " PRIVATE KEY" | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g')
+public_key=$(openssl pkey -in /tmp/k1.prv.pem -pubout | grep -v " PUBLIC KEY" | base64pem -d | tail --bytes=32 | base32 | sed 's/=//g')
+rm /tmp/k1.prv.pem
+
+echo "[*] Configuring ClientOnionAuth"
+grep -qxF 'ClientOnionAuthDir /var/lib/tor/onion_auth' /etc/tor/torrc || echo 'ClientOnionAuthDir /var/lib/tor/onion_auth' >> /etc/tor/torrc
+mkdir -p /var/lib/tor/onion_auth
+echo "bisqmonorsysbgqnma5ghacqgc2pyobk5gezlfo4q5wkemq66r47vmqd:descriptor:x25519:$private_key" > /var/lib/tor/onion_auth/bisqmonorsysbgqnma5ghacqgc2pyobk5gezlfo4q5wkemq66r47vmqd.auth_private
+chown -R debian-tor:debian-tor /var/lib/tor/onion_auth
 
 echo "[*] Symlink libjvm.so for collectd to work"
 ln -s /usr/lib/jvm/openjdk-11.0.2/lib/server/libjvm.so /lib/x86_64-linux-gnu/libjvm.so || true
@@ -63,8 +78,7 @@ echo "[*] Add monitor parameter to bisq seednode service"
 ( patch -u /etc/default/bisq.env || true ) <<EOF
 --- bisq.env.old        2022-12-07 12:07:14.481493232 +0000
 +++ /etc/default/bisq.env       2022-12-07 12:13:58.370281467 +0000
-@@ -40,3 +40,6 @@
-
+@@ -46,2 +46,5 @@
  # set to true for BSQ markets
  BISQ_DUMP_STATISTICS=false
 +
@@ -75,35 +89,41 @@ EOF
 ( patch -u /etc/systemd/system/bisq.service || true ) <<EOF
 --- bisq.service.old    2022-12-07 12:07:00.653481418 +0000
 +++ /etc/systemd/system/bisq.service    2022-12-07 12:07:56.417573388 +0000
-@@ -27,6 +27,7 @@
+@@ -27,4 +27,5 @@
            --rpcPassword=\${BITCOIN_RPC_PASS} \\
            --dumpBlockchainData=\${BISQ_DUMP_BLOCKCHAIN} \\
            --dumpStatistics=\${BISQ_DUMP_STATISTICS} \\
 +          --seedNodeReportingServerUrl=\${BISQ_REPORTINGSERVERURL} \\
-           --torControlPort=9051
-
- ExecStop=/bin/kill \${MAINPID}
+           --torControlPort=\${BISQ_EXTERNAL_TOR_PORT} \\
 EOF
 
+echo "[*] Updating systemd daemon configuration"
 systemctl daemon-reload
-
+systemctl enable tor
+systemctl enable nginx.service
+systemctl enable collectd.service
+systemctl enable http-to-socks-proxy@bisq-monitor-2002
+systemctl enable http-to-socks-proxy@bisq-monitor-13002
 
 echo "[*] Restarting services"
 set +e
+systemctl restart tor
+systemctl restart nginx.service
+systemctl restart collectd.service
+systemctl restart http-to-socks-proxy@bisq-monitor-2002
+systemctl restart http-to-socks-proxy@bisq-monitor-13002
 service bisq status >/dev/null 2>&1
 [ $? != 4 ] && systemctl restart bisq.service
 service bisq-pricenode status >/dev/null 2>&1
 [ $? != 4 ] && systemctl restart bisq-pricenode.service
-systemctl restart nginx.service
-systemctl restart collectd.service
 
 echo '[*] Done!'
 
 echo '  '
-echo '[*] Report this certificate to the monitoring team!'
+echo '[*] Provide the following to the monitoring team!'
 echo '----------------------------------------------------------------'
 echo "Server: $onionaddress"
 echo '  '
-cat /etc/nginx/cert.crt
+echo "Public key: $public_key"
 echo '----------------------------------------------------------------'
 echo '  '

--- a/scripts/nginx.conf
+++ b/scripts/nginx.conf
@@ -8,31 +8,20 @@ events {
 
 stream {
 
-	log_format basic '$remote_addr [$time_local] '
-	                 '$protocol Status $status Sent $bytes_sent Received $bytes_received '
-	                 'Time $session_time';
+    log_format basic '$remote_addr [$time_local] '
+                     '$protocol Status $status Sent $bytes_sent Received $bytes_received '
+                     'Time $session_time';
 
-	error_log syslog:server=unix:/dev/log;
-	access_log syslog:server=unix:/dev/log basic;
+    error_log syslog:server=unix:/dev/log;
+    access_log syslog:server=unix:/dev/log basic;
 
-	server {
-		listen 127.0.0.1:2003;
-		proxy_pass monitor.bisq.network:2002;
-		proxy_ssl on;
-
-		proxy_ssl_certificate /etc/nginx/cert.crt;
-		proxy_ssl_certificate_key /etc/nginx/cert.key;
-
-		proxy_ssl_session_reuse on;
-	}
-        server {
-                listen 127.0.0.1:13003;
-                proxy_pass monitor.bisq.network:13002;
-                proxy_ssl on;
-
-                proxy_ssl_certificate /etc/nginx/cert.crt;
-                proxy_ssl_certificate_key /etc/nginx/cert.key;
-
-                proxy_ssl_session_reuse on;
-        }
+    server {
+        listen 127.0.0.1:2003;
+        proxy_pass 127.0.0.1:9081;
+    }
+    
+    server {
+        listen 127.0.0.1:13003;
+        proxy_pass 127.0.0.1:9082;
+    }
 }


### PR DESCRIPTION
This changes the way nodes report to the monitor, using Tor rather than clearnet. Providing additional privacy so that they do not need to expose their IP address to the monitor.

I ran this script on my seed nodes and added them to the monitor.
https://monitor.bisq.network/d/xJETG0FVz/seed-nodes?orgId=1&from=now-24h&to=now&refresh=5s
https://monitor.bisq.network/d/qclhStdWz/server-metrics?orgId=1&refresh=5s

Once this is merged, I can follow up with all infrastructure operators to run this script and get their nodes added to the monitor.